### PR TITLE
added upload started and finished events

### DIFF
--- a/resources/views/upload.blade.php
+++ b/resources/views/upload.blade.php
@@ -55,14 +55,18 @@ $pondProperties = collect($pondProperties)
       pond.setOptions({
           allowMultiple: isMultiple,
           server: {
-              process: (fieldName, file, metadata, load, error, progress) => {
-                  @this.upload('{{ $wireModelAttribute }}', file, load, error, progress);
+              process: async (fieldName, file, metadata, load, error, progress) => {
+                  $dispatch('filepond-upload-started');
+                  await @this.upload('{{ $wireModelAttribute }}', file, (response) => {
+                      load(response);
+                      $dispatch('filepond-upload-finished', { response });
+                  }, error, progress);
               },
               revert: (filename, load) => {
                   @this.revert('{{ $wireModelAttribute }}', filename, load);
               },
               remove: (file, load) => {
-              console.log(file);
+                  console.log(file);
                   @this.remove('{{ $wireModelAttribute }}', file.name);
                   load();
               },


### PR DESCRIPTION
Added **upload started and finished** events to make it easy to deal with upload progress from outside the component.
## Let me Explain
I used this component and i love it, thank you for your hard work.
I just wanted to know when the upload starts and ends to disable/enable the submit button in my forms.
The problem was using the wire:loading attribute resulted in the button getting enabled and disabled two times for some reason but using the events it was fixed.