### PR TITLE
Restore customization of placeholder

### DIFF
--- a/resources/views/upload.blade.php
+++ b/resources/views/upload.blade.php
@@ -69,7 +69,6 @@ $pondLocalizations = __('livewire-filepond::filepond');
                   load();
               },
           },
-          labelIdle: @js($placeholder),
           required: @js($required),
           disabled: @js($disabled),
       });
@@ -77,6 +76,8 @@ $pondLocalizations = __('livewire-filepond::filepond');
       pond.setOptions(@js($pondLocalizations));
 
       pond.setOptions(@js($pondProperties));
+
+      pond.setOptions({ labelIdle: @js($placeholder) });
 
       pond.addFiles(files)
       pond.on('addfile', (error, file) => {


### PR DESCRIPTION
Localization broke the ability to customize the placeholder.

Moving the placeholder setOptions after localization restores this functionality.

This maintains the ability to use the default placeholder value with localization.