### PR TITLE
add Accept attribute on input.file

### DIFF
--- a/resources/views/upload.blade.php
+++ b/resources/views/upload.blade.php
@@ -91,5 +91,5 @@ $pondLocalizations = __('livewire-filepond::filepond');
       });
     }"
 >
-    <input type="file" x-ref="input">
+    <input type="file" x-ref="input" accept="{{ $attributes->get('accept') }}">
 </div>


### PR DESCRIPTION
The accept attribute on an <input type="file"> element is used to limit the types of files that users can select when uploading. For example, if you set accept="image/*", it will prompt users to choose only image files. However, it’s important to note that this attribute only provides guidance on the types of files users should select and isn’t a foolproof security measure. Users can still bypass this restriction by manipulating their browser or the file input directly, so you should always perform server-side validation to ensure that only allowed file types are processed.