### PR TITLE
Enable or disable revert methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Optionally, you can use these component properties to customize the component:
 - `required`: Make the file input required. Default: `false`.
 - `disabled`: Disable the file input. Default: `false`.
 - `placeholder`: Placeholder text for the file input. Default: `Drag & Drop your files or <span class="filepond--label-action"> Browse </span>`.
+- `revert` : Enable or disable revert methods. Default: `true`
 
 Additionally, you can also pass [any property that the Filepond component accepts](https://pqina.nl/filepond/docs/api/instance/properties/). Make sure to use kebab case the property. For example, to set the maximum number of files to 5, you can do this:
 

--- a/resources/views/upload.blade.php
+++ b/resources/views/upload.blade.php
@@ -3,6 +3,7 @@
     'required' => false,
     'disabled' => false,
     'placeholder' => __('Drag & Drop your files or <span class="filepond--label-action"> Browse </span>'),
+    'revert' => true,
 ])
 
 @php
@@ -17,6 +18,7 @@ $pondProperties = $attributes->except([
     'disabled',
     'multiple',
     'wire:model',
+    'revert',
 ]);
 
 // convert keys from kebab-case to camelCase
@@ -34,6 +36,7 @@ $pondLocalizations = __('livewire-filepond::filepond');
     x-data="{
         model: @entangle($wireModelAttribute),
         isMultiple: @js($multiple),
+        allowRevert: @js($revert)
         current: undefined,
         files: [],
         async loadModel() {
@@ -64,7 +67,7 @@ $pondLocalizations = __('livewire-filepond::filepond');
                       $dispatch('filepond-upload-finished', {'{{ $wireModelAttribute }}': response });
                   }, error, progress);
               },
-              revert: async (filename, load) => {
+              revert: allowRevert ? './revert' : async (filename, load) => {
                   await @this.revert('{{ $wireModelAttribute }}', filename, load);
                   $dispatch('filepond-upload-reverted', '{{ $wireModelAttribute }}');
               },


### PR DESCRIPTION
I would love if we can enable or disable revert . 

Would be better UX , when user click button cancel we remove the image , rathen then needing of click cancel button twice in order to remove the file . 

With revert true

https://github.com/user-attachments/assets/18680e62-3380-4cdf-b7ee-ed589b0b9e78


With revert false 

https://github.com/user-attachments/assets/a9a77672-c295-4742-98e4-0264907725a0

