### PR TITLE
Fix labelIdle localization bug to show correct label

### DIFF
--- a/resources/views/upload.blade.php
+++ b/resources/views/upload.blade.php
@@ -1,3 +1,7 @@
+@php
+(isset($placeholder)) ? $isCustomPlaceholder = true : $isCustomPlaceholder = false;
+@endphp
+
 @props([
     'multiple' => false,
     'required' => false,
@@ -82,7 +86,9 @@ $pondLocalizations = __('livewire-filepond::filepond');
 
       pond.setOptions(@js($pondProperties));
 
+      @if($isCustomPlaceholder)
       pond.setOptions({ labelIdle: @js($placeholder) });
+      @endif
 
       pond.addFiles(files)
       pond.on('addfile', (error, file) => {

--- a/resources/views/upload.blade.php
+++ b/resources/views/upload.blade.php
@@ -1,5 +1,5 @@
 @php
-(isset($placeholder)) ? $isCustomPlaceholder = true : $isCustomPlaceholder = false;
+$isCustomPlaceholder = isset($placeholder);
 @endphp
 
 @props([


### PR DESCRIPTION
Version: 1.2.3
PHP: 8.2
Laravel 11

Issue https://github.com/spatie/livewire-filepond/issues/10 introduced a bug for the labelIdle property.

The value from the localization file was overwritten by the second call to setOptions, causing it to always display the default English value.

`Drag & Drop your files or <span class="filepond--label-action"> Browse </span>`

https://github.com/spatie/livewire-filepond/blob/8e69e561b136d1eb67e6fd53c42fb379cc575304/resources/views/upload.blade.php#L81-L85

This PR checks whether a custom placeholder value was passed from the component in order to determine if the second call should be triggered.