### PR TITLE
Allow Server Side validation during upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,35 @@ App::setLocale('id'); // change to Indonesian for example
 ```
 The last method can be used to change the locale on the fly. Like when a user changes the language (You need to implement this yourself).
 
+## Server Side Validation on upload
+
+Optionally you can validate the uploaded file immedialetely. This is handy to inform the user of an error and process file uploads without clicking a button.
+
+```php
+use Livewire\Component;
+use Spatie\LivewireFilepond\WithFilePond;
+
+class MyLivewireComponent extends Component
+{
+    use WithFilePond;
+    
+    public $file;
+
+    public function rules(): array
+    {
+        return [
+            'file' => 'required|mimetypes:image/jpg,image/jpeg,image/png|max:3000',
+        ];
+    }
+    public function validateUploadedFile()
+    {
+        $this->validate();
+
+        return true;
+    }
+}
+```
+
 ## Publishing assets
 
 Livewire Filepond automatically loads the scripts through an endpoint. If you want to serve the assets directly, you can publish them:

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The last method can be used to change the locale on the fly. Like when a user ch
 
 ## Server Side Validation on upload
 
-Optionally you can validate the uploaded file immedialetely. This is handy to inform the user of an error and process file uploads without clicking a button.
+Optionally, you can validate the uploaded file immediately. This is useful to inform the user of an error and process file uploads without requiring the user to click a button.
 
 ```php
 use Livewire\Component;

--- a/resources/views/upload.blade.php
+++ b/resources/views/upload.blade.php
@@ -59,9 +59,17 @@ $pondLocalizations = __('livewire-filepond::filepond');
           server: {
               process: async (fieldName, file, metadata, load, error, progress) => {
                   $dispatch('filepond-upload-started', '{{ $wireModelAttribute }}');
-                  await @this.upload('{{ $wireModelAttribute }}', file, (response) => {
-                      load(response);
-                      $dispatch('filepond-upload-finished', {'{{ $wireModelAttribute }}': response });
+                  await @this.upload('{{ $wireModelAttribute }}', file, async (response) => {
+                    const validationResult  = await @this.call('validateUploadedFile', response);
+                        // Check server validation result
+                        if (validationResult === true) {
+                            // File is valid, dispatch the upload-finished event
+                            load(response);
+                            $dispatch('filepond-upload-finished', { '{{ $wireModelAttribute }}': response });
+                        } else {
+                            // Throw error after validating server side
+                            error('Filepond Api Ignores This Message');
+                        }
                   }, error, progress);
               },
               revert: async (filename, load) => {

--- a/resources/views/upload.blade.php
+++ b/resources/views/upload.blade.php
@@ -60,7 +60,7 @@ $pondLocalizations = __('livewire-filepond::filepond');
               process: async (fieldName, file, metadata, load, error, progress) => {
                   $dispatch('filepond-upload-started', '{{ $wireModelAttribute }}');
                   await @this.upload('{{ $wireModelAttribute }}', file, async (response) => {
-                    const validationResult  = await @this.call('validateUploadedFile', response);
+                    let validationResult  = await @this.call('validateUploadedFile', response);
                         // Check server validation result
                         if (validationResult === true) {
                             // File is valid, dispatch the upload-finished event
@@ -69,6 +69,7 @@ $pondLocalizations = __('livewire-filepond::filepond');
                         } else {
                             // Throw error after validating server side
                             error('Filepond Api Ignores This Message');
+                            $dispatch('filepond-upload-reset', '{{ $wireModelAttribute }}');
                         }
                   }, error, progress);
               },

--- a/src/WithFilePond.php
+++ b/src/WithFilePond.php
@@ -62,6 +62,14 @@ trait WithFilePond
         app(LivewireManager::class)->updateProperty($this, $property, $newFiles);
     }
 
+    /**
+     * Default returns true, override in your component
+     */
+    public function validateUploadedFile(): bool
+    {
+        return true;
+    }
+
     public function resetFilePond(string $property): void
     {
         $this->reset($property);


### PR DESCRIPTION
This PR adds a step during the upload process to validate the uploaded file on the server side.

Use case: I allow users to upload a single file with specific restrictions. I handle the file directly during the upload without using a form button, making server-side validation essential.

This feature is optional, so those who don't need it won't have to modify their existing code.

Server side validation returns error (multiple set to true)
![file-server-error](https://github.com/user-attachments/assets/c8e52a05-7036-4cf9-a8de-104e15b4045c)

Example without server side validation (multiple set to true)
![File-Success](https://github.com/user-attachments/assets/f2e1f2fc-e7cf-4b28-9be1-1213863b6182)

Example for a single file with server side validation (multiple set to false)
![Single-File-Error](https://github.com/user-attachments/assets/16e37d6a-1dae-46a1-be72-b59ea80e321d)
