### PR TITLE
Add new filepond-upload-completed event & update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,16 @@ App::setLocale('id'); // change to Indonesian for example
 ```
 The last method can be used to change the locale on the fly. Like when a user changes the language (You need to implement this yourself).
 
+## Events
+
+Optionally, you can use these Alpine.js events when needed:
+
+- `filepond-upload-started`: Started file upload.
+- `filepond-upload-finished`: Finished file upload.
+- `filepond-upload-reverted`: File upload reverted by user.
+- `filepond-upload-file-removed`: File removed from list by user.
+- `filepond-upload-completed`: All files in the list have been processed and uploaded.
+
 ## Server Side Validation on upload
 
 Optionally, you can validate the uploaded file immediately. This is useful to inform the user of an error and process file uploads without requiring the user to click a button.

--- a/resources/views/upload.blade.php
+++ b/resources/views/upload.blade.php
@@ -104,6 +104,11 @@ $pondLocalizations = __('livewire-filepond::filepond');
           if (error) console.log(error);
       });
 
+      // All files have been processed and uploaded, dispatch the upload-completed event 
+      pond.on('processfiles', () => {
+          $dispatch('filepond-upload-completed', {'attribute' : '{{ $wireModelAttribute }}'});
+      });
+
       $wire.on('filepond-reset-{{ $wireModelAttribute }}', () => {
           pond.removeFiles();
       });


### PR DESCRIPTION
- New Feature: Added a new Alpine.js event that dispatches when all elements in a list have been successfully uploaded to the backend. This event can be useful for scenarios such as enabling a button only after all files have been uploaded and processed.

- Documentation: Updated the README to include documentation for all existing events as well as the newly added event.