### PR TITLE
fix(WithFilePond): correctly filter file array when removing a file

### DIFF
--- a/src/WithFilePond.php
+++ b/src/WithFilePond.php
@@ -15,12 +15,13 @@ trait WithFilePond
     public function remove($property, $filename): void
     {
         $file = Str::after($filename, config('app.url'));
-
+        $data = $this->getPropertyValue($property);
+        $filtered = array_values(array_filter($data, fn($item) => $item !== $file));
         app(LivewireManager::class)->updateProperty(
             $this,
             $property,
             is_array($this->getPropertyValue($property))
-                ? []
+                ? $filtered
                 : null,
         );
 


### PR DESCRIPTION
Ensure that the file array is properly filtered when removing a file to avoid losing other files in the array. This change updates the logic to filter out the specific file being removed while preserving the remaining files.