### PR TITLE
[Fix] Incorrect Placeholder Usage in Indonesian Translation

### DIFF
--- a/resources/lang/id/filepond.php
+++ b/resources/lang/id/filepond.php
@@ -35,7 +35,7 @@ return [
     'imageValidateSizeLabelImageSizeTooSmall' => 'Citra terlalu kecil',
     'imageValidateSizeLabelImageSizeTooBig' => 'Citra terlalu besar',
     'imageValidateSizeLabelExpectedMinSize' => 'Ukuran minimum adalah {minWidth} × {minHeight}',
-    'imageValidateSizeLabelExpectedMaxSize' => 'Ukuran maksimum adalah {minWidth} × {minHeight}',
+    'imageValidateSizeLabelExpectedMaxSize' => 'Ukuran maksimum adalah {maxWidth} × {maxHeight}',
     'imageValidateSizeLabelImageResolutionTooLow' => 'Resolusi terlalu rendah',
     'imageValidateSizeLabelImageResolutionTooHigh' => 'Resolusi terlalu tinggi',
     'imageValidateSizeLabelExpectedMinResolution' => 'Resolusi minimum adalah {minResolution}',


### PR DESCRIPTION
The Indonesian translation for the imageValidateSizeLabelExpectedMaxSize string incorrectly uses {minWidth} and {minHeight} placeholders instead of {maxWidth} and {maxHeight}.

Updated to use correct max variables.