### PR TITLE
Support Laravel 13

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -20,9 +20,12 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.5, 8.4, 8.3, 8.2]
-        laravel: ['11.*', '12.*']
+        laravel: ['11.*', '12.*', '13.*']
         stability: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 13.*
+            testbench: 11.*
+            carbon: '^2.63|^3.0'
           - laravel: 12.*
             testbench: 10.*
             carbon: '^2.63|^3.0'

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,6 +22,9 @@ jobs:
         php: [8.5, 8.4, 8.3, 8.2]
         laravel: ['11.*', '12.*', '13.*']
         stability: [prefer-lowest, prefer-stable]
+        exclude:
+          - php: 8.2
+            laravel: '13.*'
         include:
           - laravel: 13.*
             testbench: 11.*

--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,9 @@
         "nunomaduro/collision": "^8.8.3",
         "larastan/larastan": "^3.9.2",
         "orchestra/testbench": "^9.0.0|^10.9|^11.0",
-        "pestphp/pest": "^3.8.5",
-        "pestphp/pest-plugin-arch": "^3.1.1",
-        "pestphp/pest-plugin-laravel": "^3.2",
+        "pestphp/pest": "^3.8.5|^4.0",
+        "pestphp/pest-plugin-arch": "^3.1.1|^4.0",
+        "pestphp/pest-plugin-laravel": "^3.2|^4.0",
         "phpstan/extension-installer": "^1.4.3",
         "phpstan/phpstan-deprecation-rules": "^2.0.3",
         "phpstan/phpstan-phpunit": "^2.0.12"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/contracts": "^11.0||^12.0",
+        "illuminate/contracts": "^11.0|^12.0|^13.0",
         "livewire/livewire": "^4.1.3",
         "spatie/laravel-package-tools": "^1.92.7"
     },
@@ -27,7 +27,7 @@
         "laravel/pint": "^1.27",
         "nunomaduro/collision": "^8.8.3",
         "larastan/larastan": "^3.9.2",
-        "orchestra/testbench": "^9.0.0||^10.9",
+        "orchestra/testbench": "^9.0.0|^10.9|^11.0",
         "pestphp/pest": "^3.8.5",
         "pestphp/pest-plugin-arch": "^3.1.1",
         "pestphp/pest-plugin-laravel": "^3.2",


### PR DESCRIPTION
## Summary

- Allow `illuminate/contracts` ^13.0 and `orchestra/testbench` ^11.0 in composer.json
- Add Laravel 13 to the CI test matrix with testbench 11.* and carbon ^2.63|^3.0
- Fix double pipe separators (`||`) to single pipe (`|`) in composer.json version constraints